### PR TITLE
Insert missing semicolons

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2017,7 +2017,7 @@ function printIndexerDeclarationBody(path, options, print) {
     docs.push(
       " ",
       "=>",
-      indent(group(concat([line, path.call(print, expression, 0)])))
+      indent(group(concat([line, path.call(print, expression, 0), ";"])))
     );
   }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -2054,7 +2054,7 @@ function printOperatorDeclarationBody(path, options, print) {
     concat([
       " ",
       "=>",
-      indent(group(concat([line, path.call(print, "expression", 0)])))
+      indent(group(concat([line, path.call(print, "expression", 0), ";"])))
     ])
   );
 }

--- a/test/AllInOne.Formatted.cs
+++ b/test/AllInOne.Formatted.cs
@@ -934,7 +934,7 @@ namespace Comments.XmlComments.UndocumentedKeywords
         // Expression bodies on method-like members
         public Point Move(int dx, int dy) => new Point(x + dx, y + dy);
 
-        public static Complex operator +(Complex a, Complex b) => a.Add(b)
+        public static Complex operator +(Complex a, Complex b) => a.Add(b);
 
         public static implicit operator string(Person p)
             => p.First + " " + p.Last;

--- a/test/AllInOne.Formatted.cs
+++ b/test/AllInOne.Formatted.cs
@@ -944,7 +944,7 @@ namespace Comments.XmlComments.UndocumentedKeywords
         // Expression bodies on property-like function members
         public string Name => First + " " + Last;
 
-        public int this[long id] => id
+        public int this[long id] => id;
 
         private void NoOp()
         {


### PR DESCRIPTION
Indexer & operator declarations were missing their semicolons when declared as expression bodied members.