### PR TITLE
Allow switch section without statement

### DIFF
--- a/src/csharp/CSharpParser.g4
+++ b/src/csharp/CSharpParser.g4
@@ -470,7 +470,7 @@ local_constant_declaration
     ;
 
 switch_section
-    : switch_label+ statement_list
+    : switch_label+ statement_list?
     ;
 
 switch_label

--- a/src/printer.js
+++ b/src/printer.js
@@ -2687,12 +2687,14 @@ function printSwitchStatement(path, options, print) {
 }
 
 function printSwitchSection(path, options, print) {
-  return group(
-    concat([
-      join(hardline, path.map(print, "switch_label")),
+  const docs = [join(hardline, path.map(print, "switch_label"))];
+
+  if (getAny(path.getValue(), "statement_list")) {
+    docs.push(
       indent(concat([hardline, path.call(print, "statement_list", 0)]))
-    ])
-  );
+    );
+  }
+  return group(concat(docs));
 }
 
 function printSwitchLabel(path, options, print) {

--- a/test/AllInOne.Formatted.cs
+++ b/test/AllInOne.Formatted.cs
@@ -236,6 +236,11 @@ namespace My.Moy
             arr[0] = new int[5, 5]; // as opposed to arr[0,0] = new int[5];
             arr[0][0, 0] = 47;
             int[] arrayTypeInference = new [] { 0, 1 };
+
+            // case without statement
+            switch (1) { case 2: }
+
+            // switch without case
             switch (3) { }
             switch (i)
             {

--- a/test/AllInOne.cs
+++ b/test/AllInOne.cs
@@ -198,6 +198,10 @@ namespace My.Moy
             arr[0] = new int[5,5];  // as opposed to arr[0,0] = new int[5];
             arr[0][0,0] = 47;
             int[] arrayTypeInference = new[] { 0, 1, };
+
+            // case without statement
+            switch(1) { case 2: }
+            // switch without case
             switch (3) { }
             switch (i)
             {


### PR DESCRIPTION
For whatever reason, you can have an empty `case` switch section, but not an empty `default` switch section. I don't know why the compiler allows this, but so should we. [Sharplab example](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEA3GUCWAZgJ5oAmIA1AD4ACATAIwCwAULQMwAEDXAwlwDebLqJ7daKLgFkAFAEohIsSoDOAd3wYwACy6zGiwVzABDVTC70QXAL7LR91raA==)