### PR TITLE
C# 7 & 7.2 Numeric Literals

### DIFF
--- a/src/csharp/CSharpLexer.g4
+++ b/src/csharp/CSharpLexer.g4
@@ -138,11 +138,14 @@ IDENTIFIER:          '@'? IdentifierOrKeyword;
 
 //B.1.8 Literals
 // 0.Equals() would be parsed as an invalid real (1. branch) causing a lexer error
-LITERAL_ACCESS:      [0-9]+ IntegerTypeSuffix? '.' '@'? IdentifierOrKeyword;
-INTEGER_LITERAL:     [0-9]+ IntegerTypeSuffix?;
-HEX_INTEGER_LITERAL: '0' [xX] HexDigit+ IntegerTypeSuffix?;
-BINARY_INTEGER_LITERAL: '0' [bB] BinaryDigit+ IntegerTypeSuffix?;
-REAL_LITERAL:        [0-9]* '.' [0-9]+ ExponentPart? [FfDdMm]? | [0-9]+ ([FfDdMm] | ExponentPart [FfDdMm]?);
+LITERAL_ACCESS:         DecimalDigitsWithSeparators IntegerTypeSuffix? '.' '@'? IdentifierOrKeyword;
+INTEGER_LITERAL:        DecimalDigitsWithSeparators IntegerTypeSuffix?;
+HEX_INTEGER_LITERAL:    '0' [xX] ('_' | HexDigit)* HexDigit IntegerTypeSuffix?;
+BINARY_INTEGER_LITERAL: '0' [bB] ('_' | BinaryDigit)* BinaryDigit IntegerTypeSuffix?;
+REAL_LITERAL
+    : DecimalDigitsWithSeparators? '.' DecimalDigitsWithSeparators ExponentPart? [FfDdMm]?
+    | DecimalDigitsWithSeparators ([FfDdMm] | ExponentPart [FfDdMm]?)
+    ;
 
 CHARACTER_LITERAL:                   '\'' (~['\\\r\n\u0085\u2028\u2029] | CommonCharacter) '\'';
 REGULAR_STRING:                      '"'  (~["\\\r\n\u0085\u2028\u2029] | CommonCharacter)* '"';
@@ -304,8 +307,11 @@ fragment NewLineCharacter
     | '\u2029' //'<Paragraph Separator CHARACTER (U+2029)>'
     ;
 
-fragment IntegerTypeSuffix:         [lL]? [uU] | [uU]? [lL];
-fragment ExponentPart:              [eE] ('+' | '-')? [0-9]+;
+fragment DecimalDigit: [0-9];
+fragment DecimalDigitsWithSeparators: DecimalDigit (('_' | DecimalDigit)* DecimalDigit)?;
+
+fragment IntegerTypeSuffix: [lL]? [uU] | [uU]? [lL];
+fragment ExponentPart:      [eE] ('+' | '-')? DecimalDigitsWithSeparators;
 
 fragment CommonCharacter
     : SimpleEscapeSequence

--- a/src/csharp/CSharpLexer.g4
+++ b/src/csharp/CSharpLexer.g4
@@ -141,6 +141,7 @@ IDENTIFIER:          '@'? IdentifierOrKeyword;
 LITERAL_ACCESS:      [0-9]+ IntegerTypeSuffix? '.' '@'? IdentifierOrKeyword;
 INTEGER_LITERAL:     [0-9]+ IntegerTypeSuffix?;
 HEX_INTEGER_LITERAL: '0' [xX] HexDigit+ IntegerTypeSuffix?;
+BINARY_INTEGER_LITERAL: '0' [bB] BinaryDigit+ IntegerTypeSuffix?;
 REAL_LITERAL:        [0-9]* '.' [0-9]+ ExponentPart? [FfDdMm]? | [0-9]+ ([FfDdMm] | ExponentPart [FfDdMm]?);
 
 CHARACTER_LITERAL:                   '\'' (~['\\\r\n\u0085\u2028\u2029] | CommonCharacter) '\'';
@@ -432,6 +433,7 @@ fragment UnicodeEscapeSequence
     ;
 
 fragment HexDigit : [0-9] | [A-F] | [a-f];
+fragment BinaryDigit : [0-1];
 
 // Unicode character classes
 fragment UnicodeClassLU

--- a/src/csharp/CSharpParser.g4
+++ b/src/csharp/CSharpParser.g4
@@ -968,6 +968,7 @@ literal
     | string_literal
     | INTEGER_LITERAL
     | HEX_INTEGER_LITERAL
+    | BINARY_INTEGER_LITERAL
     | REAL_LITERAL
     | CHARACTER_LITERAL
     | NULL

--- a/test/AllInOne.Formatted.cs
+++ b/test/AllInOne.Formatted.cs
@@ -1105,6 +1105,15 @@ namespace Comments.XmlComments.UndocumentedKeywords
         }
 
         int binaryLiterals = 0b01 + 0B10;
+
+        void DigitSeparators()
+        {
+            int bin = 0b_1001_1010_0001_0100;
+            int hex = 0x1b_a0_44_fe;
+            int dec = 33_554_432;
+            int weird = 1_2__3___4____5_____6______7_______8________9;
+            double real = 1_000.111_1e-1_000;
+        }
     }
 }
 

--- a/test/AllInOne.Formatted.cs
+++ b/test/AllInOne.Formatted.cs
@@ -1103,6 +1103,8 @@ namespace Comments.XmlComments.UndocumentedKeywords
             where T : unmanaged
         {
         }
+
+        int binaryLiterals = 0b01 + 0B10;
     }
 }
 

--- a/test/AllInOne.cs
+++ b/test/AllInOne.cs
@@ -894,6 +894,8 @@ namespace Comments.XmlComments.UndocumentedKeywords
         }
 
         void UnmanagedConstraint<T>() where T : unmanaged { }
+
+        int binaryLiterals = 0b01 + 0B10;
     }
 }
 

--- a/test/AllInOne.cs
+++ b/test/AllInOne.cs
@@ -896,6 +896,15 @@ namespace Comments.XmlComments.UndocumentedKeywords
         void UnmanagedConstraint<T>() where T : unmanaged { }
 
         int binaryLiterals = 0b01 + 0B10;
+
+        void DigitSeparators()
+        {
+            int bin = 0b_1001_1010_0001_0100;
+            int hex = 0x1b_a0_44_fe;
+            int dec = 33_554_432;
+            int weird = 1_2__3___4____5_____6______7_______8________9;
+            double real = 1_000.111_1e-1_000;
+        }
     }
 }
 


### PR DESCRIPTION
Support for C# 7 [numeric literal improvements](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#numeric-literal-syntax-improvements).
Specifically:
  - [binary literals](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.0/binary-literals)
  - [digit separators](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.0/digit-separators)
  - [leading digit separators](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/leading-separator) (C# 7.2)