### PR TITLE
Fix vscodeLanguageIds from cs to csharp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const languages = [
     aceMode: "csharp",
     codemirrorMode: "clike",
     extensions: [".cs", ".cake", ".cshtml", ".csx"],
-    vscodeLanguageIds: ["cs"],
+    vscodeLanguageIds: ["csharp"],
     linguistLanguageId: 42
   }
 ];


### PR DESCRIPTION
Visual Studio Code known language identifiers are here:
[https://code.visualstudio.com/docs/languages/identifiers](https://code.visualstudio.com/docs/languages/identifiers)

According to this page, C# should be `csharp` instead of `cs`.

As a result of this change, Format on Save now works on VSCode as well as using prettier from the CLI.